### PR TITLE
Fix AVR compile

### DIFF
--- a/nix/avr-gcc-libc.nix
+++ b/nix/avr-gcc-libc.nix
@@ -22,6 +22,8 @@ stdenv.mkDerivation {
   sourceRoot = ".";
 
   nativeBuildInputs = [ texinfo automake autoconf libtool ];
+
+  hardeningDisable = [ "format" ];
   
   buildInputs = [ gmp mpfr libmpc zlib ];
   


### PR DESCRIPTION
Fixes the following error during AVR compile:
../../../libcpp/expr.c:684:39: error: format not a string literal and no format arguments [-Werror=format-security]
           virtual_location, 0, message);

Change copied from:
   https://github.com/NixOS/nixpkgs/blob/master/pkgs/development/misc/avr-gcc-with-avr-libc/default.nix