### PR TITLE
Ad849x support

### DIFF
--- a/config_system/generator/generate.py
+++ b/config_system/generator/generate.py
@@ -2075,7 +2075,17 @@ def generate(config_root_data, cfg_name, main_template):
                 def option(conversion_config):
                     gen.add_aprinter_include('printer/thermistor/InterpolationTableThermistor_tables.h')
                     return TemplateExpr('InterpolationTableThermistorService', ['InterpolationTableE3dPt100'])
-                
+
+                @conversion_sel.option('Ad849xFormula')
+                def option(conversion_config):
+                    gen.add_aprinter_include('printer/thermistor/Ad849xFormula.h')
+                    return TemplateExpr('Ad849xFormulaService', [
+                        gen.add_float_config('{}HeaterTempOffsetVoltage'.format(name), conversion_config.get_float('OffsetVoltage')),
+                        gen.add_float_config('{}HeaterTempSlope'.format(name), conversion_config.get_float('Slope')),
+                        gen.add_float_config('{}HeaterTempMinTemp'.format(name), conversion_config.get_float('MinTemp')),
+                        gen.add_float_config('{}HeaterTempMaxTemp'.format(name), conversion_config.get_float('MaxTemp')),
+                    ])
+
                 conversion = heater.do_selection('conversion', conversion_sel)
                 
                 for control in heater.enter_config('control'):


### PR DESCRIPTION
not working (yet), but compiles :)

Is there a way to get the scaling of the adc? It is important in this case as the output of these modules = temperature*5mV/K + 1.25V. Hardcoding to 3.3V seems a bit ugly (in case AREF isn't yet available) as it will not work for systems that use 5V for AREF.

Adding another parameter to the module would be somewhat a middle ground between the effort of adding it to each HAL and hardcoding.

BTW: I think that InterpolationTableE3dPt100 has the same issue.